### PR TITLE
Bump sbt-precog

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
-addSbtPlugin("com.precog" % "sbt-precog" % "2.4.9")
+addSbtPlugin("com.precog" % "sbt-precog" % "2.4.11")
 addSbtPlugin("com.precog" % "sbt-quasar-plugin" % "0.2.8")


### PR DESCRIPTION
I just realized the last publish failed when `sbt-trickle` tried to download `sbt` from a Lightbend URL that no longer accepts HTTP requests. This `sbt-precog` depends on a new sbt-trickle